### PR TITLE
Add tag based filtering

### DIFF
--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -119,6 +119,10 @@ article > p {
     font-weight: inherit;
 }
 
+sl-tag::part(base):hover {
+    background: rgb(186, 186, 186);
+}
+
 /* finer grid for people */
 #people .card-grid {
     grid-template-columns: repeat(auto-fit, 200px);

--- a/theme/assets/js/card_control.js
+++ b/theme/assets/js/card_control.js
@@ -1,0 +1,50 @@
+// Get all the cards and tags on the page
+const allCards = document.querySelectorAll("sl-card")
+const allTags = document.querySelectorAll("sl-tag")
+
+// Add the buttonPress function as an onClick event listener
+allTags.forEach(item => item.addEventListener("click", function() { buttonPress(this) }))
+
+/**
+ * Show all the cards on the page.
+ * Attached to a button to reset filtering.
+ */
+function resetButton(){
+    allCards.forEach(showCard)
+}
+
+/**
+ * Hides cards that do not have tags with the same value as this tag.
+ * Attached to a tag to filter other elements.
+ * @param {object} element - The tag element clicked on.
+ */
+function buttonPress(element){
+    search_term = element.innerText
+    allCards.forEach(hideCard)
+}
+
+/**
+ * Checks whether a card should be hidden based on the contents of a clicked tag.
+ * @param {object} el - The card element to be checked 
+ */
+function hideCard(el) {
+    // Get all tags within card
+    childTags = Array.from(el.querySelectorAll("sl-tag"));
+    // See if any of those tags match the text of the clicked tag
+    contains = childTags.some((Cel) => (Cel.innerText === search_term));
+    
+    // If yes then show, if no then hide
+    if (contains){
+        showCard(el)
+    } else {
+        el.style.display = 'none';
+    }
+}
+
+/**
+ * Show a card element
+ * @param {object} el - The card element to be shown 
+ */
+function showCard(el) {
+    el.style.display = '';
+}

--- a/theme/templates/master.jinja2
+++ b/theme/templates/master.jinja2
@@ -9,6 +9,7 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn/shoelace-autoloader.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono">
     <link rel="stylesheet" href="/assets/css/index.css">
+    <script src="/assets/js/card_control.js" defer></script>
 
     <title>eegmanylabs</title>
 </head>


### PR DESCRIPTION
Here's the code for adding tag based filtering.

I haven't been able to build the site using the `syrinx .` command, and have been editing the existing html manually to test functionality. So, I'm fairly sure that this will work when you rebuild, but not 100%.

The only thing missing on the site is a way to reset the filter. In the test I did I just added a reset button in a `div` and set the `onclick` action to `resetButton()`, but adding that to the template would add it to all pages whether it is needed or not, so I'm not sure how to proceed with that.