### PR TITLE
Update tag styling

### DIFF
--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -289,45 +289,28 @@ sl-card::part(footer) {
     color: teal;
 }
 
-#people a[title="replicator"] {
-    white-space: nowrap;
-    padding: 5px;
+#people sl-tag::part(base), #publications sl-tag::part(base) {
     border-radius: 3px;
     color:white;
-    background-color:deepskyblue;
-    margin: 2px;
-    text-decoration: none;
+    font-weight: bold;
 }
 
-#people a[title="coordinator"] {
-    white-space: nowrap;
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#people sl-tag.coordinator::part(base) {
     background-color: teal;
-    margin: 2px;
-    text-decoration: none;
 }
 
-#people a[title="steering"] {
-    white-space: nowrap;
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#people sl-tag.replicator::part(base) {
+    background-color: deepskyblue;
+}
+
+#people sl-tag.steering::part(base) {
     background-color: rgb(163, 106, 0);
-    margin: 2px;
-    text-decoration: none;
 }
 
-#people a[title="advisor"] {
-    white-space: nowrap;
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#people sl-tag.advisor::part(base) {
     background-color: rgb(128, 0, 122);
-    margin: 2px;
-    text-decoration: none;
 }
+
 
 /*
     PUBLICATIONS PAGE
@@ -362,29 +345,14 @@ a[href^="https://scholar.google.com/citations?user=ueMcfOcAAAAJ"] {
     overflow-y: scroll;
 }
 
-#publications a[title="preprint"] {
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#publications sl-tag.preprint::part(base) {
     background-color: rgb(69, 183, 209);
-    margin: 2px;
-    text-decoration: none;
 }
 
-#publications a[title="preregistration"] {
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#publications sl-tag.preregistration::part(base) {
     background-color: rgb(210, 199, 72);
-    margin: 2px;
-    text-decoration: none;
 }
 
-#publications a[title="published"] {
-    padding: 5px;
-    border-radius: 3px;
-    color:white;
+#publications sl-tag.published::part(base) {
     background-color: rgb(81, 187, 160);
-    margin: 2px;
-    text-decoration: none;
 }

--- a/theme/templates/card_full.jinja2
+++ b/theme/templates/card_full.jinja2
@@ -17,7 +17,7 @@
 
 
   {% for tag in leaf.front['Tags'] %}
-    <sl-tag size="small" pill>{{ tag }}</sl-tag>
+    <sl-tag size="small" pill class={{tag}}>{{ tag }}</sl-tag>
   {% endfor %}
 
   <div slot="footer">


### PR DESCRIPTION
Tags on publications and people pages now styled in the same way with colours added for each type of tag.

I couldn't see existing colours for the replications page, but if you'd like me to add some let me know what you'd like them to be (can also be placeholders). 