### PR TITLE
Add dropdown filter

### DIFF
--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -125,6 +125,14 @@ sl-tag::part(base):hover {
     background: rgb(186, 186, 186);
 }
 
+sl-menu-item::part(label) {
+    text-transform: capitalize;
+}
+
+.card-filter {
+    margin-bottom: 20px;
+}
+
 /* finer grid for people */
 #people .card-grid {
     grid-template-columns: repeat(auto-fit, 220px);

--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -105,7 +105,7 @@ article > p {
     grid-auto-rows: auto;
     column-gap: 10px;
     row-gap: 10px;
-    justify-content: space-evenly;
+    justify-content: space-between;
 }
 
 .preview-grid {

--- a/theme/assets/js/card_control.js
+++ b/theme/assets/js/card_control.js
@@ -1,27 +1,36 @@
 // Get all the cards and tags on the page
-const allCards = document.querySelectorAll("sl-card")
-const allTags = document.querySelectorAll("sl-tag")
+const allCards = document.querySelectorAll("sl-card");
+const allTags = document.querySelectorAll("sl-tag");
+const dropDown = document.querySelector("sl-dropdown");
+const ddMenu = document.querySelector("sl-menu");
 
-// Add the buttonPress function as an onClick event listener
-allTags.forEach(item => item.addEventListener("click", function() { buttonPress(this) }))
+let search_term;
 
-/**
- * Show all the cards on the page.
- * Attached to a button to reset filtering.
- */
-function resetButton(){
-    allCards.forEach(showCard)
+if (allTags.length > 0) {
+    let tags = new Set();
+
+    for (node of allTags) {
+        tags.add(node.innerText);
+    }
+
+    for (let tag of tags) {
+        item = document.createElement("sl-menu-item");
+        item.value = tag;
+        item.innerText = tag;
+        ddMenu.appendChild(item);
+    }
+    dropDown.style.display = '';
 }
 
-/**
- * Hides cards that do not have tags with the same value as this tag.
- * Attached to a tag to filter other elements.
- * @param {object} element - The tag element clicked on.
- */
-function buttonPress(element){
-    search_term = element.innerText
-    allCards.forEach(hideCard)
-}
+dropDown.addEventListener('sl-select', event => {
+    const selectedItem = event.detail.item;
+    search_term = selectedItem.value;
+    if (search_term === "none"){
+        allCards.forEach(showCard);
+    } else {
+        allCards.forEach(hideCard);
+    }
+});
 
 /**
  * Checks whether a card should be hidden based on the contents of a clicked tag.
@@ -35,7 +44,7 @@ function hideCard(el) {
     
     // If yes then show, if no then hide
     if (contains){
-        showCard(el)
+        showCard(el);
     } else {
         el.style.display = 'none';
     }

--- a/theme/templates/page.jinja2
+++ b/theme/templates/page.jinja2
@@ -8,6 +8,15 @@
         {{ index.content_html|safe }}
     </p>
 
+    <div class="card-filter">
+        <sl-dropdown style="display:none;">
+            <sl-button slot="trigger" caret>Filter</sl-button>
+            <sl-menu>
+                <sl-menu-item value="none">None</sl-menu-item>
+            </sl-menu>
+        </sl-dropdown>
+    </div>
+
     <div class="card-grid">
     {% for leaf in index.leaves %}
         {% include 'card_full.jinja2' %}


### PR DESCRIPTION
This adds the dropdown filter box, which means you can move between filters/reset the page without needing to refresh it.

I haven't managed to solve the flash as it's dynamically adding the labels to the dropdown. I can come back to that.

I'm also not sure about switching the card justification layout to `space-between`. On one hand it means that edge of the left hand most cards align with the dropdown box, but on the other it feels like there's a lot of space between card columns when there are 3 or fewer cards. What do you think?