### PR TITLE
Update publications page

### DIFF
--- a/archetypes/publications.md
+++ b/archetypes/publications.md
@@ -1,7 +1,8 @@
 +++
 SequenceNumber = "{{ DatePublishedNumber }}"
 Anchor = "{{ PublicationId }}"
-Title = "{{ AuthorsShort }} ({{ PublicationYear }}) {{ Title|truncate(50, True) }}"
+Title = "{{ Title }}"
+AuthorShort = "{{ AuthorsShort }} ({{ PublicationYear }})"
 Image = "previews/{{ PublicationId }}.pdf.png"
 PublicationId = "{{ PublicationId }}"
 Authors = "{{ Authors }}"

--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -221,6 +221,28 @@ sl-card a[href^="https://eeg100"] {
     color: teal;
 }
 
+#spin-offs img {
+	height: 270px
+}
+
+#spin-offs sl-card::part(header) {
+	 flex-grow: 0
+}
+
+#spin-offs sl-card::part(body) {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1
+}
+
+#spin-offs sl-card p:first-of-type {
+	flex-grow: 1
+}
+
+#spin-offs sl-card::part(footer) {
+	padding: 0
+}
+
 /*  
     REPLICATION PAGE
 */

--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -356,6 +356,16 @@ a[href^="https://scholar.google.com/citations?user=ueMcfOcAAAAJ"] {
 #publications sl-tag.published::part(base) {
     background-color: rgb(81, 187, 160);
 }
+
+#publications img {
+    height: 300px;
+}
+
+#publications #authors{
+    padding-top: 20px;
+    font-size: 14px;
+}
+
 /* CSS for equal sized but reactive cards */
 
 sl-card {

--- a/theme/assets/css/index.css
+++ b/theme/assets/css/index.css
@@ -356,3 +356,22 @@ a[href^="https://scholar.google.com/citations?user=ueMcfOcAAAAJ"] {
 #publications sl-tag.published::part(base) {
     background-color: rgb(81, 187, 160);
 }
+/* CSS for equal sized but reactive cards */
+
+sl-card {
+    display:grid;
+}
+
+sl-card::part(header){
+    display: flex;
+    flex-grow: 1;
+}
+
+div#card-header {
+    display: flex;
+    flex-direction: column;
+}
+
+div#title {
+    flex-grow: 1;
+}

--- a/theme/templates/card_full.jinja2
+++ b/theme/templates/card_full.jinja2
@@ -4,8 +4,13 @@
 
 <sl-card id="{{ leaf.name }}">
   
-  <div slot="header">
-    {{ leaf.front['Title'] }}
+  <div slot="header" id="card-header">
+    <div id="title">
+      {{ leaf.front['Title'] }}
+    </div>
+    <div id="authors">
+      {{ leaf.front['AuthorShort'] }}
+    </div>
   </div>
 
   <img


### PR DESCRIPTION
Updates to styling for publications page and spin-offs page.
The latter was updated as the css introduced for publications messed with the card layouts.

Publications:
![image](https://github.com/user-attachments/assets/41d1edd9-7c4b-4954-aef7-9e6dae3186fc)

Spin-offs (zoomed out slightly): 
![image](https://github.com/user-attachments/assets/7e543d7b-c822-4756-a7c7-3d108c873af6)
